### PR TITLE
Ensure env vars are loaded from available .env file

### DIFF
--- a/jvserve/cli.py
+++ b/jvserve/cli.py
@@ -5,8 +5,8 @@ import os
 import time
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Optional
-from dotenv import load_dotenv
 
+from dotenv import load_dotenv
 from jac_cloud.jaseci.security import authenticator
 from jaclang.cli.cmdreg import cmd_registry
 from jaclang.plugin.default import hookimpl


### PR DESCRIPTION
## **Type of Change**
What type of change does this PR introduce? Mark all that apply:
- [x] 🐛 Bug Fix
- [ ] 🚀 Feature Request
- [ ] 🔄 Refactor
- [ ] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

---

## **Summary**
### **What does this PR address?**

  `.env` files are currently being ignored and requires sourcing an .env with only exists within the current shell session. This means for each `jac jvserve main.jac` command you need to set env variables manually or using scripts. This PR addresses this issue by using `python-dotenv` to load env vars from the project `.env` file automatically.

---

## **Changes Made**
### High-Level Summary:
List the key changes made in this PR:
1. Modified cli.py to use `load_dotenv` from `python-dotenv` which is already a dependency from `jac-cloud`

---

## **Checklist**
Mark all that apply:
- [x] Code follows the project’s coding guidelines.
- [ ] Tests have been added or updated for new functionality.
- [ ] Documentation has been updated (if applicable).
- [x] Existing tests pass locally with these changes.
- [ ] Any dependencies introduced are justified and documented.

---

## **Steps to Test**
Provide a clear set of steps for testing the changes introduced in this PR:
1. In a new jivas project run `jac jvserve main.jac` without using the `sh/serve.sh` script end ensure the api is served