### PR TITLE
updated optional params for interact endpoint

### DIFF
--- a/jvserve/__init__.py
+++ b/jvserve/__init__.py
@@ -4,5 +4,5 @@ jvserve package initialization.
 This package provides the webserver for loading and interacting with JIVAS agents.
 """
 
-__version__ = "2.0.7"
+__version__ = "2.0.8"
 __supported__jivas__versions__ = ["2.0.0"]

--- a/jvserve/lib/agent_interface.py
+++ b/jvserve/lib/agent_interface.py
@@ -237,7 +237,7 @@ class AgentInterface:
         session_id: Optional[str] = None
         tts: Optional[bool] = None
         verbose: Optional[bool] = None
-        data: Optional[dict] = None
+        data: Optional[list[dict]] = None
         streaming: Optional[bool] = None
 
     @staticmethod
@@ -267,7 +267,7 @@ class AgentInterface:
                         "session_id": session_id or "",
                         "tts": payload.tts or False,
                         "verbose": payload.verbose or False,
-                        "data": payload.data or {},
+                        "data": payload.data or [],
                         "streaming": payload.streaming or False,
                         "reporting": False,
                     },
@@ -394,7 +394,7 @@ class AgentInterface:
                     "session_id": session_id or "",
                     "tts": payload.tts or False,
                     "verbose": payload.verbose or False,
-                    "data": payload.data or {},
+                    "data": payload.data or [],
                     "streaming": payload.streaming or False,
                     "reporting": False,
                 }


### PR DESCRIPTION
## **Type of Change**
What type of change does this PR introduce? Mark all that apply:
- [x] 🐛 Bug Fix
- [ ] 🚀 Feature Request
- [ ] 🔄 Refactor
- [ ] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

---

## **Summary**
### **What does this PR address?**
Patched mismatched datatype for 'data' on BaseModel for interact endpoint

---

## **Description**
### **Bug Fixes**:
When supplying data params to interact endpoint via REST, values do not persist into graph. This was due to a mismatch in the data type definition of the BaseModel for interact params. The data param was set to be of type Optional[dict] instead of  Optional[list[dict]] as stipulated in the interact walker. 

---

## **Checklist**
Mark all that apply:
- [x] Code follows the project’s coding guidelines.
- [x] Tests have been added or updated for new functionality.
- [ ] Documentation has been updated (if applicable).
- [x] Existing tests pass locally with these changes.
- [x] Any dependencies introduced are justified and documented.

---

## **Steps to Test**
Supply a payload like shown below, the return payload should show the data supplied.

```json
{
  "agent_id": "n:Agent:681cd5006af8b4c3211a0f91",
  "utterance": "Hello",
  "channel": "default",
  "session_id": "",
  "tts": false,
  "verbose": true,
  "data": [{"label": "images", "meta": {}, "content": ["https://randomwordgenerator.com/img/picture-generator/52e2d6414f51a814f1dc8460962e33791c3ad6e04e507440702d7edc9e4bc5_640.jpg"]}],
  "streaming": false
}
```
