### PR TITLE
2.0.11

### DIFF
--- a/jvserve/__init__.py
+++ b/jvserve/__init__.py
@@ -4,5 +4,5 @@ jvserve package initialization.
 This package provides the webserver for loading and interacting with JIVAS agents.
 """
 
-__version__ = "2.0.10"
+__version__ = "2.0.11"
 __supported__jivas__versions__ = ["2.0.0"]

--- a/jvserve/lib/file_interface.py
+++ b/jvserve/lib/file_interface.py
@@ -7,6 +7,10 @@ import logging
 import os
 from abc import ABC, abstractmethod
 
+from dotenv import load_dotenv
+
+load_dotenv(".env")
+
 # Interface type determined by environment variable, defaults to local
 FILE_INTERFACE = os.environ.get("JIVAS_FILE_INTERFACE", "local")
 DEFAULT_FILES_ROOT = os.environ.get("JIVAS_FILES_ROOT_PATH", ".files")


### PR DESCRIPTION
## **Type of Change**
What type of change does this PR introduce? Mark all that apply:
- [ ] 🐛 Bug Fix
- [x] 🚀 Feature Request
- [ ] 🔄 Refactor
- [ ] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

---

## **Summary**
### **What does this PR address?**
Handles TrueSelph/jivas#63

Static file serving is maintained for local files that aren't proxied. All proxied files go through a new `/f/{path}` endpoint. S3 files are now streamed directly from s3 via a new `/files/{path}` endpoint when not shortened.

## **Checklist**
Mark all that apply:
- [x] Code follows the project’s coding guidelines.
- [ ] Tests have been added or updated for new functionality.
- [ ] Documentation has been updated (if applicable).
- [x] Existing tests pass locally with these changes.
- [ ] Any dependencies introduced are justified and documented.

---

## **Additional Context**
If necessary, provide additional context, screenshots, or relevant references for the changes in this PR.

---

## **Questions or Concerns**
Are there any open questions or areas of concern related to this PR? If so, mention them here.
