### PR TITLE
Add Command for FileServe Proxy

### DIFF
--- a/jvserve/__init__.py
+++ b/jvserve/__init__.py
@@ -4,5 +4,5 @@ jvserve package initialization.
 This package provides the webserver for loading and interacting with JIVAS agents.
 """
 
-__version__ = "2.0.11"
+__version__ = "2.0.12"
 __supported__jivas__versions__ = ["2.0.0"]

--- a/jvserve/cli.py
+++ b/jvserve/cli.py
@@ -211,7 +211,9 @@ class JacCmd:
             _run(app, host=host, port=port)
 
         @cmd_registry.register
-        def jvproxyserve(host: str = "0.0.0.0", port: int = 9000) -> None:
+        def jvproxyserve(
+            directory: str, host: str = "0.0.0.0", port: int = 9000
+        ) -> None:
             """Launch the file proxy server for remote files."""
             # load FastAPI
             from bson import ObjectId

--- a/tests/test_jvserve.py
+++ b/tests/test_jvserve.py
@@ -118,6 +118,25 @@ class JVServeCliTest(unittest.TestCase):
             os.remove(f"{directory}/test.txt")
             os.rmdir(directory)
 
+    def test_jvproxyserve_runs(self) -> None:
+        """Ensure `jac jvproxyserve` runs successfully."""
+        try:
+            server_process = subprocess.Popen(
+                ["jac", "jvproxyserve", "--port", "9100"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+
+            # Wait for the proxy server to be ready
+            self.wait_for_server("http://127.0.0.1:9100/docs")
+
+            res = httpx.get("http://127.0.0.1:9100/docs")
+            self.assertEqual(res.status_code, 200)
+
+        finally:
+            server_process.kill()
+
     def tearDown(self) -> None:
         """Cleanup after each test."""
         self.stop_server()

--- a/tests/test_jvserve.py
+++ b/tests/test_jvserve.py
@@ -121,8 +121,9 @@ class JVServeCliTest(unittest.TestCase):
     def test_jvproxyserve_runs(self) -> None:
         """Ensure `jac jvproxyserve` runs successfully."""
         try:
+            directory = "test_files"
             server_process = subprocess.Popen(
-                ["jac", "jvproxyserve", "--port", "9100"],
+                ["jac", "jvproxyserve", directory, "--port", "9100"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,


### PR DESCRIPTION
## Type of Change
- [ ] 🐛 Bug Fix
- [x] 🚀 Feature Request
- [x] 🔄 Refactor
- [ ] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

## Summary
This pull request introduces a new `jvproxyserve` command for serving remote files via a proxy server, refactors the existing `jvfileserve` command to simplify its logic, and adds a test to ensure the proper functionality of `jvproxyserve`.

## Description
### New Feature: Proxy Server for Remote Files
- Added the `jvproxyserve` command to launch a proxy server for remote files, leveraging FastAPI with CORS middleware.
- Defines proxy routes specifically for S3-based file storage.

### Refactoring: Simplification of `jvfileserve`
- Removed redundant checks for the `FILE_INTERFACE` variable in the `jvfileserve` command.
- Directly sets the environment variable `JIVAS_FILES_ROOT_PATH` for the file root path.
- Simplified static file mounting logic by using the `directory` parameter directly.

### Testing: New Test for Proxy Server
- Added a test `test_jvproxyserve_runs` to ensure the `jvproxyserve` command runs correctly and serves the API documentation endpoint.

## Changes Made
1. Introduced the `jvproxyserve` command with support for remote file serving via FastAPI and S3.
2. Refactored the `jvfileserve` command to simplify logic and improve maintainability.
3. Added a test for the `jvproxyserve` command to verify it runs successfully and serves API documentation.
