### PR TITLE
Handle aborting of llm text streams on interact endpoint

### DIFF
--- a/jvserve/lib/agent_interface.py
+++ b/jvserve/lib/agent_interface.py
@@ -1,12 +1,12 @@
 """Agent Interface class and methods for interaction with Jivas."""
 
+import asyncio
 import json
 import logging
 import os
 import string
 import time
 import traceback
-import asyncio
 from asyncio import sleep
 from typing import Any, AsyncGenerator, Dict, Iterator, List, Optional
 from urllib.parse import quote, unquote
@@ -292,7 +292,7 @@ class AgentInterface:
                     interaction_node = response.interaction_node
 
                     async def generate(
-                        generator: Iterator, request
+                        generator: Iterator, request: Request
                     ) -> AsyncGenerator[str, None]:
                         """
                         Asynchronously yield data chunks from a response generator in Server-Sent Events (SSE) format.


### PR DESCRIPTION
## **Type of Change**
What type of change does this PR introduce? Mark all that apply:
- [ ] 🐛 Bug Fix
- [x] 🚀 Feature Request
- [ ] 🔄 Refactor
- [ ] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

---

## **Summary**
### **What does this PR address?**
Provide a concise summary of the changes introduced in this pull request. Specify if it resolves an issue, adds a feature, or refactors code.

Addresses: TrueSelph/tschat#7

---

## **Description**
Gracefully, handle the interruption of text streaming when a request is cancelled. In this case, the interaction object is updated to save the text that had been generated up to the point in which the interact request was cancelled.

---

## **Checklist**
Mark all that apply:
- [x] Code follows the project’s coding guidelines.
- [ ] Tests have been added or updated for new functionality.
- [ ] Documentation has been updated (if applicable).
- [x] Existing tests pass locally with these changes.
- [ ] Any dependencies introduced are justified and documented.

---

## **Steps to Test**
Provide a clear set of steps for testing the changes introduced in this PR:
1. Call the interact endpoint with stream = true
2. Cancel the request before full text generation is complete
3. Check that a partial generation is saved in the interaction object